### PR TITLE
Fixed paths

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -41,7 +41,6 @@ if github.pr_title.include? "[WIP]"
     # auto_label.delete("WIP")
 end
 
-
 forgot_tests = !git.modified_files.include?("/src/tests/tests.py")
 
 if forgot_tests and not declared_trivial


### PR DESCRIPTION
Danger now warns you if you forgot to add a test unless you mark PR trivial