### PR TITLE
Added UID to message + moved check user to init

### DIFF
--- a/src/core/grade_notifier.py
+++ b/src/core/grade_notifier.py
@@ -174,6 +174,7 @@ def welcome_message():
         .add("👋 Welcome to the Grade Notifier 🚨") \
         .newline() \
         .newline() \
+        .add("Your UID is: ".format(custom_hash(user.get_username())))
         .add("You're all set up. You should see your current grades below!") \
         .newline() \
         .add("The notifier will message you whenever a grade changes (or is added)!") \

--- a/src/core/grade_notifier.py
+++ b/src/core/grade_notifier.py
@@ -81,7 +81,7 @@ def send_text(message, sendNumber):
     Converts a changelog array to a message
     Changelog: The list of classes which have had grade changes
 '''
-def create_text_message(change_log, is_welcome):
+def create_text_message(change_log, is_welcome=False):
 
     # Message header
     new_message = None
@@ -174,7 +174,7 @@ def welcome_message():
         .add("👋 Welcome to the Grade Notifier 🚨") \
         .newline() \
         .newline() \
-        .add("Your UID is: ".format(custom_hash(user.get_username())))
+        .add("Your UID is: ".format(custom_hash(user.get_username()))) \
         .add("You're all set up. You should see your current grades below!") \
         .newline() \
         .add("The notifier will message you whenever a grade changes (or is added)!") \

--- a/src/core/initializegn.py
+++ b/src/core/initializegn.py
@@ -16,6 +16,7 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 import argparse
 import time
 import os
+import re
 import requests
 import getpass
 import subprocess

--- a/src/core/initializegn.py
+++ b/src/core/initializegn.py
@@ -26,6 +26,7 @@ from lxml import html
 from helper.fileManager import create_dir
 from helper.constants import log_path, instance_path, script_path, abs_repo_path
 from helper.helper import print_to_screen, custom_hash
+from login_flow.loginState import LoginState
 from dotenv import load_dotenv
 from os.path import join, dirname
 

--- a/src/core/initializegn.py
+++ b/src/core/initializegn.py
@@ -25,9 +25,10 @@ from lxml import html
 from helper.fileManager import create_dir
 from helper.constants import log_path
 from helper.constants import script_path, abs_repo_path
-from helper.helper import print_to_screen
+from helper.helper import print_to_screen, custom_hash
 from dotenv import load_dotenv
 from os.path import join, dirname
+
 
 """Initialize Grade-Notifier
 """
@@ -80,6 +81,13 @@ def run(username, password, school, phone):
                 stdout=outfile,
                 stderr=outfile)
 
+def check_user_exists(username):
+    stored_username = custom_hash(username)
+    file_path = instance_path(state)
+    open(file_path, 'a').close()
+    with open(file_path, 'r+') as file:
+        return re.search(
+            '^{0}'.format(re.escape(stored_username)), file.read(), flags=re.M)
 
 def parse():
     parser = argparse.ArgumentParser(
@@ -109,6 +117,16 @@ def main():
         number = input(
             "Enter phone number: ") if not args.phone else args.phone
         prod = False if not args.prod else True
+
+
+        if(check_user_exists(username)):
+            print_to_screen(
+                "Seems that you already have a session running.\n" \
+                + "If you think there is a mistake, contact me @ Ehud.Adler62@qmail.cuny.edu",
+                "error",
+                "Oh No!",
+            )
+            return
 
         api = cunyfirstapi.CUNYFirstAPI(username, password)
         api.login()

--- a/src/core/initializegn.py
+++ b/src/core/initializegn.py
@@ -23,8 +23,7 @@ import cunyfirstapi
 from helper import constants
 from lxml import html
 from helper.fileManager import create_dir
-from helper.constants import log_path
-from helper.constants import script_path, abs_repo_path
+from helper.constants import log_path, instance_path, script_path, abs_repo_path
 from helper.helper import print_to_screen, custom_hash
 from dotenv import load_dotenv
 from os.path import join, dirname
@@ -81,7 +80,7 @@ def run(username, password, school, phone):
                 stdout=outfile,
                 stderr=outfile)
 
-def check_user_exists(username):
+def check_user_exists(username, state):
     stored_username = custom_hash(username)
     file_path = instance_path(state)
     open(file_path, 'a').close()
@@ -118,8 +117,8 @@ def main():
             "Enter phone number: ") if not args.phone else args.phone
         prod = False if not args.prod else True
 
-
-        if(check_user_exists(username)):
+        state = LoginState.determine_state(args)
+        if(check_user_exists(username, state)):
             print_to_screen(
                 "Seems that you already have a session running.\n" \
                 + "If you think there is a mistake, contact me @ Ehud.Adler62@qmail.cuny.edu",


### PR DESCRIPTION
Added UID to message. Reason for this is now we can hash the username for the logs as well and still allow us to access them given the user reaches out.

Moved the check_user method to init so we can short circuit if the instance exists rather than assuming all is good and having to send a message.